### PR TITLE
Removed the README.readtext() from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ import setuptools
 HERE = pathlib.Path(__file__).parent
 
 # The text of the README file
-README = (HERE / "README.md").read_text()
+# README = (HERE / "README.md").read_text()
 
 setuptools.setup(
     name="sports",
     version='0.1.0',
     python_requires=">=3.8",
     description="",
-    long_description=README,
+    # long_description=README,
     long_description_content_type="text/markdown",
     url="https://github.com/roboflow/sports",
     author="Piotr Skalski",


### PR DESCRIPTION
**The Error**
--------------
Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  
   return codecs.charmap_decode(input,self.errors,decoding_table)[0]
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 3227: character maps to <undefined>
      
**Solution** 
-----
To comment out the .read_text() in the setup.py --> create a venv --> install the git repo as a python package 